### PR TITLE
Display virtualenv

### DIFF
--- a/pygmalion.zsh-theme
+++ b/pygmalion.zsh-theme
@@ -6,13 +6,23 @@ prompt_setup_pygmalion(){
   ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[yellow]%}⚡%{$reset_color%}"
   ZSH_THEME_GIT_PROMPT_CLEAN=""
 
-  base_prompt='%{$fg[magenta]%}%n%{$reset_color%}%{$fg[cyan]%}@%{$reset_color%}%{$fg[yellow]%}%m%{$reset_color%}%{$fg[red]%}:%{$reset_color%}%{$fg[cyan]%}%0~%{$reset_color%}'
+  base_prompt='%(1V. (%1v) . )%{$fg[magenta]%}%n%{$reset_color%}%{$fg[cyan]%}@%{$reset_color%}%{$fg[yellow]%}%m%{$reset_color%}%{$fg[red]%}:%{$reset_color%}%{$fg[cyan]%}%0~%{$reset_color%}'
   post_prompt='%{$fg[cyan]%}⇒%{$reset_color%}  '
 
   base_prompt_nocolor=$(echo "$base_prompt" | perl -pe "s/%\{[^}]+\}//g")
   post_prompt_nocolor=$(echo "$post_prompt" | perl -pe "s/%\{[^}]+\}//g")
 
   precmd_functions+=(prompt_pygmalion_precmd)
+  precmd_functions+=(virtualenv)
+}
+
+
+function virtualenv {
+    if [[ -z $VIRTUAL_ENV ]] then
+        psvar[1]=''
+    else
+        psvar[1]=${VIRTUAL_ENV##*/}
+    fi
 }
 
 prompt_pygmalion_precmd(){
@@ -23,7 +33,7 @@ prompt_pygmalion_precmd(){
 
   local nl=""
 
-  if [[ $prompt_length -gt 40 ]]; then
+  if [[ $prompt_length -gt 50 ]]; then
     nl=$'\n';
   fi
   pipe='%{$fg[red]%}|%{$reset_color%}'

--- a/pygmalion.zsh-theme
+++ b/pygmalion.zsh-theme
@@ -33,7 +33,7 @@ prompt_pygmalion_precmd(){
 
   local nl=""
 
-  if [[ $prompt_length -gt 50 ]]; then
+  if [[ $prompt_length -gt 100 ]]; then
     nl=$'\n';
   fi
   pipe='%{$fg[red]%}|%{$reset_color%}'


### PR DESCRIPTION
If there's an active Virtualenv, it will be displayed first on the prompt.
Also, the Pygmalion theme adds a line break before the cursor if the prompt message (including virtualenv info and git) is larger than 40 chars.  This limit was increased, because most people have larger screens than that.